### PR TITLE
use MediaQuery.sizeOf

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -78,7 +78,7 @@ class _NewtonConfigurationPageState extends State<NewtonConfigurationPage> {
   }
 
   Effect currentActiveEffect() {
-    final size = MediaQuery.of(context).size;
+    final size = MediaQuery.sizeOf(context);
     return _selectedAnimation.instantiate(
       size: size,
       effectConfiguration: _effectConfiguration,

--- a/lib/src/newton.dart
+++ b/lib/src/newton.dart
@@ -125,7 +125,7 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
     setState(() {
       _activeEffects.add(
         effect
-          ..surfaceSize = MediaQuery.of(context).size
+          ..surfaceSize = MediaQuery.sizeOf(context)
           ..postEffectCallback = _onPostEffect
           ..stateChangeCallback = _onEffectStateChanged,
       );


### PR DESCRIPTION
the MediaQuery docs say https://api.flutter.dev/flutter/widgets/MediaQuery-class.html

> For example, to learn the size of the current media (e.g., the window containing your app), you can use [MediaQuery.sizeOf](https://api.flutter.dev/flutter/widgets/MediaQuery/sizeOf.html): MediaQuery.sizeOf(context).

> Querying the current media using specific methods (for example, [MediaQuery.sizeOf](https://api.flutter.dev/flutter/widgets/MediaQuery/sizeOf.html) and [MediaQuery.paddingOf](https://api.flutter.dev/flutter/widgets/MediaQuery/paddingOf.html)) will cause your widget to rebuild automatically whenever the property you query changes.

> On the other hand, querying using [MediaQuery.of](https://api.flutter.dev/flutter/widgets/MediaQuery/of.html) will cause your widget to rebuild automatically whenever any field of the [MediaQueryData](https://api.flutter.dev/flutter/widgets/MediaQueryData-class.html) changes (e.g., if the user rotates their device). Therefore, if you are only concerned with one or a few fields of [MediaQueryData](https://api.flutter.dev/flutter/widgets/MediaQueryData-class.html), prefer using the specific methods (for example: [MediaQuery.sizeOf](https://api.flutter.dev/flutter/widgets/MediaQuery/sizeOf.html) and [MediaQuery.paddingOf](https://api.flutter.dev/flutter/widgets/MediaQuery/paddingOf.html)).