### PR TITLE
only re-setup effects if they are provided with the activeEffects Newton property

### DIFF
--- a/lib/src/newton.dart
+++ b/lib/src/newton.dart
@@ -149,7 +149,9 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
   @override
   void didUpdateWidget(Newton oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _setupEffectsFromWidget();
+    if (oldWidget.activeEffects != widget.activeEffects) {
+      _setupEffectsFromWidget();
+    }
   }
 
   void _setupEffectsFromWidget() {


### PR DESCRIPTION
this fixes a problem that an effect added with `NewtonState.addEffect` gets removed as soon as the child of the Newton changes. This is a really unexpected behaviour.

I'm not sure whether or not this is the correct solution. (it seems to work for my use-case)

I think a better solution could be to make _setupEffectsFromWidget ignore all effects added with addEffect. But I don't know what the best way to do that would be.