### PR TITLE
Support runtime active effects

### DIFF
--- a/lib/src/effects/effect.dart
+++ b/lib/src/effects/effect.dart
@@ -58,6 +58,17 @@ abstract class Effect<T extends AnimatedParticle> {
   /// Register a callback if you want to be notified that a post effect is occurring
   ValueChanged<Effect>? postEffectCallback;
 
+  /// Root effect that triggered this effect
+  Effect get rootEffect => _rootEffect ?? this;
+
+  set rootEffect(Effect rootEffect) {
+    _rootEffect = rootEffect;
+  }
+
+  Effect? _rootEffect;
+
+  bool addedAtRuntime = false;
+
   EffectState _state = EffectState.running;
 
   /// Current state of the effect
@@ -127,7 +138,11 @@ abstract class Effect<T extends AnimatedParticle> {
         final postEffectBuilder =
             activeParticle.particle.configuration.postEffectBuilder;
         if (postEffectBuilder != null) {
-          postEffectCallback?.call(postEffectBuilder(activeParticle.particle));
+          postEffectCallback?.call(
+            postEffectBuilder(activeParticle.particle)
+              ..rootEffect = rootEffect
+              ..addedAtRuntime = addedAtRuntime,
+          );
         }
       }
       return animationOver;

--- a/lib/src/newton.dart
+++ b/lib/src/newton.dart
@@ -133,6 +133,17 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
     });
   }
 
+  /// Remove a effect from the list of active effects.
+  ///
+  /// The `removeEffect` method allows you to dynamically remove a particle effect from the list
+  /// of active effects.
+  removeEffect(Effect effect) {
+    setState(() {
+      _activeEffects.removeWhere((effect) => effect.rootEffect == effect);
+      _pendingActiveEffects.removeWhere((effect) => effect.rootEffect == effect);
+    });
+  }
+
   @override
   void dispose() {
     _ticker.stop(canceled: true);

--- a/lib/src/newton.dart
+++ b/lib/src/newton.dart
@@ -159,7 +159,8 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
   removeEffect(Effect effect) {
     setState(() {
       _activeEffects.removeWhere((effect) => effect.rootEffect == effect);
-      _pendingActiveEffects.removeWhere((effect) => effect.rootEffect == effect);
+      _pendingActiveEffects
+          .removeWhere((effect) => effect.rootEffect == effect);
     });
   }
 
@@ -183,6 +184,7 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
     if (widget.activeEffects != oldWidget.activeEffects) {
       _pendingActiveEffects.removeWhere(_isEffectRemoved);
       _activeEffects.removeWhere(_isEffectRemoved);
+      _setupEffectsFromWidget();
     }
   }
 
@@ -193,10 +195,7 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
   }
 
   void _setupEffectsFromWidget() {
-    _pendingActiveEffects.clear();
-    _activeEffects
-      ..clear()
-      ..addAll(widget.activeEffects);
+    _activeEffects.addAll(widget.activeEffects);
     for (var effect in _activeEffects) {
       effect
         ..postEffectCallback = _onPostEffect

--- a/lib/src/newton.dart
+++ b/lib/src/newton.dart
@@ -126,6 +126,7 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
       _activeEffects.add(
         effect
           ..surfaceSize = MediaQuery.sizeOf(context)
+          ..addedAtRuntime = true
           ..postEffectCallback = _onPostEffect
           ..stateChangeCallback = _onEffectStateChanged,
       );
@@ -149,7 +150,16 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
   @override
   void didUpdateWidget(Newton oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _setupEffectsFromWidget();
+    if (widget.activeEffects != oldWidget.activeEffects) {
+      _pendingActiveEffects.removeWhere(_isEffectRemoved);
+      _activeEffects.removeWhere(_isEffectRemoved);
+    }
+  }
+
+  bool _isEffectRemoved(Effect<AnimatedParticle> effect) {
+    // Keep only pending effects that are still active even if it's a post effect
+    return !widget.activeEffects.contains(effect.rootEffect) &&
+        !effect.addedAtRuntime;
   }
 
   void _setupEffectsFromWidget() {


### PR DESCRIPTION
This pr aims to improve 3 things:
* It was possible to add an effect at runtime but not to remove it...
* The didUpdate was too brutal, now we can detect if effect is removed (also applies to post effect)
* Runtime effects are now ignored from the didUpdate widget. An effect added at runtime must be removed at runtime.