### PR TITLE
No need to have 2 widgets for foreground + background effects

### DIFF
--- a/lib/src/effects/effect.dart
+++ b/lib/src/effects/effect.dart
@@ -63,6 +63,9 @@ abstract class Effect<T extends AnimatedParticle> {
   /// Current state of the effect
   EffectState get state => _state;
 
+  /// Should the effect be played in foreground?
+  bool get foreground => effectConfiguration.foreground;
+
   void Function(Effect, EffectState)? _stateChangeCallback;
 
   /// Callback to be notified when state has changed

--- a/lib/src/effects/effect_configuration.dart
+++ b/lib/src/effects/effect_configuration.dart
@@ -79,6 +79,9 @@ class EffectConfiguration {
 
   final Trail trail;
 
+  /// Should the effect be played in foreground
+  final bool foreground;
+
   /// Creates an instance of `EffectConfiguration` with the specified parameters.
   ///
   /// All parameters have default values that can be overridden during object creation.
@@ -107,6 +110,7 @@ class EffectConfiguration {
     this.maxFadeInLimit = 0,
     this.fadeInCurve = Curves.linear,
     this.trail = const NoTrail(),
+    this.foreground = false,
   })  : assert(minDistance <= maxDistance,
             "Min distance can't be greater than max distance"),
         assert(
@@ -147,6 +151,7 @@ class EffectConfiguration {
     double? maxFadeInLimit,
     Curve? fadeInCurve,
     Trail? trail,
+    bool? foreground,
   }) {
     return EffectConfiguration(
       particleCount: particleCount ?? this.particleCount,
@@ -173,6 +178,7 @@ class EffectConfiguration {
       maxFadeInLimit: maxFadeInLimit ?? this.maxFadeInLimit,
       fadeInCurve: fadeInCurve ?? this.fadeInCurve,
       trail: trail ?? this.trail,
+      foreground: foreground ?? this.foreground,
     );
   }
 }

--- a/lib/src/newton.dart
+++ b/lib/src/newton.dart
@@ -106,14 +106,18 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
                     _activeEffects.where(_isForegroundEffect).toList();
                 return CustomPaint(
                   willChange: true,
-                  painter: NewtonPainter(
-                    shapesSpriteSheet: snapshot.data!,
-                    effects: backgroundEffects,
-                  ),
-                  foregroundPainter: NewtonPainter(
-                    shapesSpriteSheet: snapshot.data!,
-                    effects: foregroundEffects,
-                  ),
+                  painter: backgroundEffects.isNotEmpty
+                      ? NewtonPainter(
+                          shapesSpriteSheet: snapshot.data!,
+                          effects: backgroundEffects,
+                        )
+                      : null,
+                  foregroundPainter: foregroundEffects.isNotEmpty
+                      ? NewtonPainter(
+                          shapesSpriteSheet: snapshot.data!,
+                          effects: foregroundEffects,
+                        )
+                      : null,
                   child: widget.child,
                 );
               }),

--- a/lib/src/newton.dart
+++ b/lib/src/newton.dart
@@ -100,11 +100,19 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
                 for (var effect in _activeEffects) {
                   effect.surfaceSize = constraints.biggest;
                 }
+                final backgroundEffects =
+                    _activeEffects.where(_isBackgroundEffect).toList();
+                final foregroundEffects =
+                    _activeEffects.where(_isForegroundEffect).toList();
                 return CustomPaint(
                   willChange: true,
+                  painter: NewtonPainter(
+                    shapesSpriteSheet: snapshot.data!,
+                    effects: backgroundEffects,
+                  ),
                   foregroundPainter: NewtonPainter(
                     shapesSpriteSheet: snapshot.data!,
-                    effects: _activeEffects,
+                    effects: foregroundEffects,
                   ),
                   child: widget.child,
                 );
@@ -115,6 +123,10 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
           }
         });
   }
+
+  bool _isBackgroundEffect(effect) => !effect.foreground;
+
+  bool _isForegroundEffect(effect) => effect.foreground;
 
   /// Adds a new particle effect to the list of active effects.
   ///

--- a/website/docs/custom.md
+++ b/website/docs/custom.md
@@ -150,6 +150,7 @@ Enjoy your firework!
 
 ## All Effect Properties
 
+- `foreground`: `bool` - Should the effect be played in foreground? Default: `false`
 - `emitDuration`: `int` - Duration between particle emissions. Default: `100`
 - `particlesPerEmit`: `int` - Number of particles emitted per emission. Default: `1`
 - `emitCurve`: `Curve` - Curve to control the emission timing. Default: `Curves.decelerate`


### PR DESCRIPTION
The foreground property was determined by the presence of a child widget. Make it clearer by adding a foreground property in the effect configuration. Newton can display background + foreground effects.