### PR TITLE
Add missing setState to clearEffects

### DIFF
--- a/lib/src/newton.dart
+++ b/lib/src/newton.dart
@@ -172,9 +172,11 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
   }
 
   void clearEffects() {
-    _activeEffects.removeWhere((effect) {
-      effect.postEffectCallback = null;
-      return true;
+    setState(() {
+      _activeEffects.removeWhere((effect) {
+        effect.postEffectCallback = null;
+        return true;
+      });
     });
   }
 


### PR DESCRIPTION
Simple fix that adds the missing setState to the `newtonKey.currentState?.clearEffects();` method.