### PR TITLE
Fix name collision in NewtonState.removeEffect

### DIFF
--- a/lib/src/newton.dart
+++ b/lib/src/newton.dart
@@ -158,9 +158,8 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
   /// of active effects.
   removeEffect(Effect effect) {
     setState(() {
-      _activeEffects.removeWhere((effect) => effect.rootEffect == effect);
-      _pendingActiveEffects
-          .removeWhere((effect) => effect.rootEffect == effect);
+      _activeEffects.removeWhere((e) => e.rootEffect == effect);
+      _pendingActiveEffects.removeWhere((e) => e.rootEffect == effect);
     });
   }
 


### PR DESCRIPTION
Fixes #24

I'm not really sure about the single letter name but it works this way 