### PR TITLE
Add pause/resume

### DIFF
--- a/lib/src/newton.dart
+++ b/lib/src/newton.dart
@@ -152,6 +152,13 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
     });
   }
 
+  /// Check if the list of active effects is empty.
+  ///
+  /// Returns `true` if the list of active effects is empty; otherwise, `false`.
+  isEffectsListEmpty() {
+    return _activeEffects.isEmpty;
+  }
+
   /// Remove a effect from the list of active effects.
   ///
   /// The `removeEffect` method allows you to dynamically remove a particle effect from the list

--- a/lib/src/newton.dart
+++ b/lib/src/newton.dart
@@ -163,6 +163,26 @@ class NewtonState extends State<Newton> with SingleTickerProviderStateMixin {
     });
   }
 
+  /// Pause all active effects.
+  ///
+  /// The `pauseEffects` method allows you to pause all active effects.
+  /// The effects will be paused and will not be updated until they are resumed.
+  pauseEffects() {
+    setState(() {
+      _activeEffects.forEach((effect) => effect.stop());
+    });
+  }
+
+  /// Resume all paused effects.
+  ///
+  /// The `resumeEffects` method allows you to resume all paused effects.
+  /// The effects will be resumed and will be updated on the next frame.
+  resumeEffects() {
+    setState(() {
+      _activeEffects.forEach((effect) => effect.start());
+    });
+  }
+
   @override
   void dispose() {
     _ticker.stop(canceled: true);


### PR DESCRIPTION
With this feature, integrators can pause the emission and wait the particles finish smoothly, and later resume if needed.